### PR TITLE
Fix when changelog using different line endings

### DIFF
--- a/src/ChangelogManagement.psm1
+++ b/src/ChangelogManagement.psm1
@@ -74,7 +74,7 @@ function Get-ChangelogData {
         else {
             $Value = (($UnreleasedTemp -split "### $ChangeType$NL")[1] -split "###")[0].TrimEnd($NL) -split $NL | ForEach-Object { $_.TrimStart("- ") }
             Set-Variable -Name "Unreleased$ChangeType" -Value $Value
-        }       
+        }
     }
     $Output.Unreleased = [PSCustomObject]@{
         "RawData" = $UnreleasedTemp
@@ -98,7 +98,7 @@ function Get-ChangelogData {
             else {
                 $Value = (($Release -split "### $ChangeType$NL")[1] -split "###")[0].TrimEnd($NL) -split $NL | ForEach-Object { $_.TrimStart("- ") }
                 Set-Variable -Name "Release$ChangeType" -Value $Value
-            }       
+            }
         }
 
         $LoopVersionNumber = $Release.Split("[")[1].Split("]")[0]
@@ -320,8 +320,8 @@ function Update-Changelog {
 
         [parameter(Mandatory=$false)]
         # Pattern used for adding links at the bottom of the Changelog when -LinkMode is set to Automatic. This
-        # is a hashtable that defines the format for the three possible types of links needed: FirstRelease, NormalRelease, 
-        # and Unreleased. The current version in the patterns should be replaced with {CUR} and the previous 
+        # is a hashtable that defines the format for the three possible types of links needed: FirstRelease, NormalRelease,
+        # and Unreleased. The current version in the patterns should be replaced with {CUR} and the previous
         # version with {PREV}. See examples for details on format of hashtable.
         [ValidateNotNullOrEmpty()]
         [hashtable]$LinkPattern
@@ -333,8 +333,13 @@ function Update-Changelog {
 
     $ChangelogData = Get-ChangelogData -Path $Path
 
-    # Create $NewRelease by removing header from old Unreleased section
-    $NewRelease = $ChangelogData.Unreleased.RawData -replace "## \[Unreleased\]$NL",""
+    <#
+        Create $NewRelease by removing header from old Unreleased section
+
+        Using the regular expression '\r?\n' to look for either CRLF or just LF.
+        This resolves issue #11.
+    #>
+    $NewRelease = $ChangelogData.Unreleased.RawData -replace "## \[Unreleased\]\r?\n",""
 
     If ([string]::IsNullOrWhiteSpace($NewRelease)) {
         Throw "No changes detected in current release, exiting."

--- a/test/ChangelogManagement.Tests.ps1
+++ b/test/ChangelogManagement.Tests.ps1
@@ -1598,7 +1598,9 @@ InModuleScope $ModuleName {
                     "and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).$NL" +
                     "$NL" +
                     "## [Unreleased]$NL" +
+                    "$NL" +
                     "### Added$NL" +
+                    "$NL" +
                     "- Unreleased Addition 1$NL" +
                     "$NL")
 
@@ -1617,7 +1619,9 @@ InModuleScope $ModuleName {
                     "## [Unreleased]$NL" +
                     "$NL" +
                     "## [1.0.0] - $Today$NL" +
+                    "$NL" +
                     "### Added$NL" +
+                    "$NL" +
                     "- Unreleased Addition 1$NL" +
                     "$NL")
             }
@@ -1727,6 +1731,49 @@ InModuleScope $ModuleName {
                     "[1.1.0]: ENTER-URL-HERE$NL" +
                     "[1.0.0]: ENTER-URL-HERE")
             }
+
+            <#
+                Regression test for issue #11.
+            #>
+            It "First Release - changelog is using different line endings than [System.Environment]::NewLine" {
+                $TestPath = "TestDrive:\CHANGELOG.md"
+
+                $SeedData = ("# Changelog`n" +
+                    "All notable changes to this project will be documented in this file.`n" +
+                    "`n" +
+                    "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),`n" +
+                    "and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).`n" +
+                    "`n" +
+                    "## [Unreleased]`n" +
+                    "`n" +
+                    "### Added`n" +
+                    "`n" +
+                    "- Unreleased Addition 1`n" +
+                    "`n")
+
+                Set-Content -Value $SeedData -Path $TestPath -NoNewline
+
+                Update-Changelog -Path $TestPath -ReleaseVersion "1.0.0" -LinkMode None
+
+                $Result = Get-Content -Path $TestPath -Raw
+
+                $ExpectedResult = "# Changelog`n" +
+                    "All notable changes to this project will be documented in this file.`n" +
+                    "`n" +
+                    "The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),`n" +
+                    "and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).`n" +
+                    "`n" +
+                    "## [Unreleased]$NL" +
+                    "$NL" +
+                    "## [1.0.0] - $Today$NL" +
+                    "`n" +
+                    "### Added`n" +
+                    "`n" +
+                    "- Unreleased Addition 1`n" +
+                    "`n"
+
+                $Result | Should -Be $ExpectedResult
+            }
         }
         It "-OutputPath" {
             $TestPath = "TestDrive:\CHANGELOG.md"
@@ -1773,7 +1820,7 @@ InModuleScope $ModuleName {
                 "$NL" +
                 "## [Unreleased]$NL" +
                 "$NL")
-                
+
             Set-Content -Value $SeedData -Path $TestPath -NoNewline
 
             { Update-Changelog -Path $TestPath -ReleaseVersion "1.0.0" -LinkMode None } | Should -Throw


### PR DESCRIPTION
Fixes so that changelog can have different line endings than [System.Environment]::NewLine suggests (issue #11).

- Fixes #11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natescherer/changelogmanagement/12)
<!-- Reviewable:end -->
