### PR TITLE
Get-ChangeLogData: Correctly returns a PSCustomTable or null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Get-ChangelogData now always outputs a PSCustomObject for the Unreleased property when there is an Unreleased section header in the changelog. The PSCustomObject property RawData will contain the Unreleased header and any change type headers that exist. The properties Added, Changed, Deprecated, Removed, Fixed, and Security will be null if there are no corresponding change type under the Unreleased section header.
+
+### Fixed
+
+- Get-ChangelogData will now return null for the property Unreleased if there are no Unreleased section header in the changelog.
+
 ## [3.0.0] - 2022-11-04
 ### Added
 - New LinkModes 'GitHub' and 'AzureDevOps' on Update-Changelog which remove the need to manually specify a LinkPattern

--- a/src/public/Get-ChangelogData.ps1
+++ b/src/public/Get-ChangelogData.ps1
@@ -69,19 +69,20 @@ function Get-ChangelogData {
         $UnreleasedTemp = $Sections[0]
         $Sections.Remove($UnreleasedTemp)
     } else {
-        $UnreleasedTemp = ""
+        $UnreleasedTemp = $null
     }
 
-    # Construct the $Output.Unreleased object
-    foreach ($ChangeType in $ChangeTypes) {
-        if ($UnreleasedTemp -notlike "*### $ChangeType*") {
-            Set-Variable -Name "Unreleased$ChangeType" -Value $null
-        } else {
-            $Value = (($UnreleasedTemp -split "### $ChangeType$FileNewline")[1] -split "###")[0].TrimEnd($FileNewline) -split $FileNewline | ForEach-Object { $_.TrimStart("- ") }
-            Set-Variable -Name "Unreleased$ChangeType" -Value $Value
+    if ($UnreleasedTemp) {
+        # Construct the $Output.Unreleased object
+        foreach ($ChangeType in $ChangeTypes) {
+            if ($UnreleasedTemp -notlike "*### $ChangeType*") {
+                Set-Variable -Name "Unreleased$ChangeType" -Value $null
+            } else {
+                $Value = (($UnreleasedTemp -split "### $ChangeType$FileNewline")[1] -split "###")[0].TrimEnd($FileNewline) -split $FileNewline | ForEach-Object { $_.TrimStart("- ") }
+                Set-Variable -Name "Unreleased$ChangeType" -Value $Value
+            }
         }
-    }
-    if ($UnreleasedAdded -or $UnreleasedChanged -or $UnreleasedDeprecated -or $UnreleasedRemoved -or $UnreleasedFixed -or $UnreleasedSecurity) {
+
         $Output.Unreleased = [PSCustomObject]@{
             "RawData" = $UnreleasedTemp
             "Link"    = (($Output.Footer -split "Unreleased\]: ")[1] -split $FileNewline)[0]
@@ -94,6 +95,8 @@ function Get-ChangelogData {
                 Security   = $UnreleasedSecurity
             }
         }
+    } else {
+        $Output.Unreleased = $null
     }
 
     # Construct the $Output.Released array

--- a/test/ChangelogManagement.Tests.ps1
+++ b/test/ChangelogManagement.Tests.ps1
@@ -281,11 +281,8 @@ InModuleScope $ModuleName {
                 Set-Content -Value $SeedDataNoUnreleased -Path $TestPathNoUnreleased -NoNewline
                 $DataNoUnreleased = Get-ChangelogData -Path $TestPathNoUnreleased
             }
-            It "Data.Unreleased.RawData" {
-                $DataNoUnreleased.Unreleased.RawData | Should -BeNullOrEmpty
-            }
-            It "Data.Unreleased.Data" {
-                $DataNoUnreleased.Unreleased.RawData | Should -BeNullOrEmpty
+            It "Data.Unreleased" {
+                $DataNoUnreleased.Unreleased | Should -BeNullOrEmpty
             }
         }
         It "Output.ReleaseNotes" {


### PR DESCRIPTION
Fixes #25 

### Changed

- Get-ChangelogData now always outputs a PSCustomObject for the Unreleased property when there is an Unreleased section header in the changelog. The PSCustomObject property RawData will contain the Unreleased header and any change type headers that exist. The properties Added, Changed, Deprecated, Removed, Fixed, and Security will be null if there are no corresponding change type under the Unreleased section header.

### Fixed

- Get-ChangelogData will now return null for the property Unreleased if there are no Unreleased section header in the changelog.